### PR TITLE
[154] Simplify edge label to display only one semantic field

### DIFF
--- a/plugins/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign
+++ b/plugins/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign
@@ -29,14 +29,14 @@
         </nodeMappings>
         <edgeMappings name="Data Source to Processor" labelDirectEdit="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@toolSections.0/@ownedTools[name='Edit%20Capacity']" semanticCandidatesExpression="aql:self.elements.eAllContents(flow::DataFlow)" semanticElements="var:self" doubleClickDescription="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@toolSections.0/@ownedTools[name='ChangeSourceAndTargetEdge']" sourceMapping="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source'] //@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Data%20Source']" targetMapping="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']" targetFinderExpression="feature:target" sourceFinderExpression="feature:source" domainClass="flow::DataFlow" useDomainElement="true">
           <style strokeColor="//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Gray']" lineStyle="dash" targetArrow="InputClosedArrow">
-            <centerLabelStyleDescription showIcon="false" labelExpression="aql:self.load + '/' +  self.capacity">
+            <centerLabelStyleDescription showIcon="false" labelExpression="aql:self.capacity">
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             </centerLabelStyleDescription>
           </style>
         </edgeMappings>
         <edgeMappings name="Processor  to Processor" labelDirectEdit="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@toolSections.0/@ownedTools[name='Edit%20Capacity']" semanticCandidatesExpression="aql:self.elements.eAllContents(flow::DataFlow)" semanticElements="var:self" doubleClickDescription="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@toolSections.0/@ownedTools[name='ChangeSourceAndTargetEdge']" sourceMapping="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']" targetMapping="//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']" targetFinderExpression="feature:target" sourceFinderExpression="feature:source" domainClass="flow::DataFlow" useDomainElement="true">
           <style strokeColor="//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Gray']">
-            <centerLabelStyleDescription showIcon="false" labelExpression="aql:self.load + '/' +  self.capacity">
+            <centerLabelStyleDescription showIcon="false" labelExpression="aql:self.capacity">
               <labelColor xsi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
             </centerLabelStyleDescription>
           </style>

--- a/samples/org.obeonetwork.sample.robot/representations.aird
+++ b/samples/org.obeonetwork.sample.robot/representations.aird
@@ -1,345 +1,339 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/table/description/1.1.0" xmlns:description_2="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:flow="http://www.obeo.fr/dsl/designer/sample/flow" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:table="http://www.eclipse.org/sirius/table/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/table/description/1.1.0 http://www.eclipse.org/sirius/table/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
-  <viewpoint:DAnalysis xmi:id="_44Bz0LBkEeGaLc01A8ddGg" selectedViews="_OxlmcLB4EeG06LGzBbJLsw _j4uugfKPEeaTM5lTgIAE1w" version="12.0.0.201704271200">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/table/description/1.1.0" xmlns:description_2="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:flow="http://www.obeo.fr/dsl/designer/sample/flow" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:table="http://www.eclipse.org/sirius/table/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/table/description/1.1.0 http://www.eclipse.org/sirius/table/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_44Bz0LBkEeGaLc01A8ddGg" selectedViews="_OxlmcLB4EeG06LGzBbJLsw _j4uugfKPEeaTM5lTgIAE1w" version="14.3.1.202003261200">
     <semanticResources>Robot.flow</semanticResources>
-    <ownedViews xmi:type="viewpoint:DView" xmi:id="_OxlmcLB4EeG06LGzBbJLsw">
+    <ownedViews xmi:type="viewpoint:DView" uid="_OxlmcLB4EeG06LGzBbJLsw">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_iaGNUPKPEeaTM5lTgIAE1w" name="Flow matrix" repPath="#_D88DMDJZEeO7iqsmL-jrBA">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_iaGNUPKPEeaTM5lTgIAE1w" name="Flow matrix" repPath="#_D88DMDJZEeO7iqsmL-jrBA">
         <description xmi:type="description_1:CrossTableDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']"/>
-        <target xmi:type="flow:System" href="Robot.flow#/"/>
+        <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_iaGNUfKPEeaTM5lTgIAE1w" name="Processors table" repPath="#_jar8IDJcEeO7iqsmL-jrBA">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_iaGNUfKPEeaTM5lTgIAE1w" name="Processors table" repPath="#_jar8IDJcEeO7iqsmL-jrBA">
         <description xmi:type="description_1:EditionTableDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']"/>
-        <target xmi:type="flow:System" href="Robot.flow#/"/>
+        <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_ezVdAKT_EeezavZXoDtFGQ" name="Topography - Local" repPath="#_ezRyoKT_EeezavZXoDtFGQ">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_ezVdAKT_EeezavZXoDtFGQ" name="Topography - Local" repPath="#_ezRyoKT_EeezavZXoDtFGQ">
         <description xmi:type="description_2:DiagramDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']"/>
-        <target xmi:type="flow:System" href="Robot.flow#/"/>
+        <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
       </ownedRepresentationDescriptors>
     </ownedViews>
-    <ownedViews xmi:type="viewpoint:DView" xmi:id="_j4uugPKPEeaTM5lTgIAE1w">
+    <ownedViews xmi:type="viewpoint:DView" uid="_j4uugPKPEeaTM5lTgIAE1w">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Performance']"/>
     </ownedViews>
-    <ownedViews xmi:type="viewpoint:DView" xmi:id="_j4uugfKPEeaTM5lTgIAE1w">
+    <ownedViews xmi:type="viewpoint:DView" uid="_j4uugfKPEeaTM5lTgIAE1w">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_mDPeQPKPEeaTM5lTgIAE1w" name="Topography - Deploy" repPath="#_mDPeQfKPEeaTM5lTgIAE1w">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_mDPeQPKPEeaTM5lTgIAE1w" name="Topography - Deploy" repPath="#_mDPeQfKPEeaTM5lTgIAE1w" changeId="6af33ee5-e793-4664-a8e7-2b3eed717aa8">
         <description xmi:type="description_2:DiagramDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']"/>
-        <target xmi:type="flow:System" href="Robot.flow#/"/>
+        <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
       </ownedRepresentationDescriptors>
     </ownedViews>
   </viewpoint:DAnalysis>
-  <table:DTable xmi:id="_D88DMDJZEeO7iqsmL-jrBA" name="Flow matrix" headerColumnWidth="160">
-    <target xmi:type="flow:System" href="Robot.flow#/"/>
-    <lines xmi:type="table:DLine" xmi:id="_dSp40DJaEeO7iqsmL-jrBA" label="DSP">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
+  <table:DTable uid="_D88DMDJZEeO7iqsmL-jrBA" headerColumnWidth="160">
+    <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
+    <lines xmi:type="table:DLine" uid="_dSp40DJaEeO7iqsmL-jrBA" label="DSP">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_9Qob4DJbEeO7iqsmL-jrBA" label="X" column="_JhHoATJaEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
+      <cells xmi:type="table:DCell" uid="_9Qob4DJbEeO7iqsmL-jrBA" label="X" column="_JhHoATJaEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
         <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_dSqf4DJaEeO7iqsmL-jrBA" label="Motion_Engine">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+    <lines xmi:type="table:DLine" uid="_dSqf4DJaEeO7iqsmL-jrBA" label="Motion_Engine">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineProcessor']"/>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_dSrG8DJaEeO7iqsmL-jrBA" label="Radar_Capture">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
+    <lines xmi:type="table:DLine" uid="_dSrG8DJaEeO7iqsmL-jrBA" label="Radar_Capture">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_9Qob4jJbEeO7iqsmL-jrBA" label="X" column="_JhHoATJaEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
+      <cells xmi:type="table:DCell" uid="_9Qob4jJbEeO7iqsmL-jrBA" label="X" column="_JhHoATJaEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
         <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_XLPbsKUqEeerOY55FDaMag" label="X" column="_XLONkKUqEeerOY55FDaMag">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
-      </cells>
-    </lines>
-    <lines xmi:type="table:DLine" xmi:id="_XLM_cKUqEeerOY55FDaMag" label="Engine">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-      <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineProcessor']"/>
-    </lines>
-    <lines xmi:type="table:DLine" xmi:id="_XLM_caUqEeerOY55FDaMag" label="GPU">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-      <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_XLQCwKUqEeerOY55FDaMag" label="X" column="_JhHoATJaEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+      <cells xmi:type="table:DCell" uid="_XLPbsKUqEeerOY55FDaMag" label="X" column="_XLONkKUqEeerOY55FDaMag">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
         <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_7ih7UDJbEeO7iqsmL-jrBA" label="Back_Camera">
-      <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
-      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
+    <lines xmi:type="table:DLine" uid="_XLM_cKUqEeerOY55FDaMag" label="Engine">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+      <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineProcessor']"/>
+    </lines>
+    <lines xmi:type="table:DLine" uid="_XLM_caUqEeerOY55FDaMag" label="GPU">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+      <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineProcessor']"/>
+      <cells xmi:type="table:DCell" uid="_XLQCwKUqEeerOY55FDaMag" label="X" column="_JhHoATJaEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
+      </cells>
+    </lines>
+    <lines xmi:type="table:DLine" uid="_7ih7UDJbEeO7iqsmL-jrBA" label="Back_Camera">
+      <target xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineDataSource']"/>
-      <cells xmi:type="table:DCell" xmi:id="_XLQCwaUqEeerOY55FDaMag" label="X" column="_XLONkaUqEeerOY55FDaMag">
-        <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
-        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
+      <cells xmi:type="table:DCell" uid="_XLQCwaUqEeerOY55FDaMag" label="X" column="_XLONkaUqEeerOY55FDaMag">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
         <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_v_930DyzEeOiYdTXWoHNAg" label="Radar">
-      <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
-      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
+    <lines xmi:type="table:DLine" uid="_v_930DyzEeOiYdTXWoHNAg" label="Radar">
+      <target xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineDataSource']"/>
-      <cells xmi:type="table:DCell" xmi:id="_yH_UQDyzEeOiYdTXWoHNAg" label="X" column="_JhIPEDJaEeO7iqsmL-jrBA">
-        <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
-        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
+      <cells xmi:type="table:DCell" uid="_yH_UQDyzEeOiYdTXWoHNAg" label="X" column="_JhIPEDJaEeO7iqsmL-jrBA">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
         <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_7ih7UTJbEeO7iqsmL-jrBA" label="Wifi">
-      <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
-      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
+    <lines xmi:type="table:DLine" uid="_7ih7UTJbEeO7iqsmL-jrBA" label="Wifi">
+      <target xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedLineMappings[name='lineDataSource']"/>
-      <cells xmi:type="table:DCell" xmi:id="_9QpC8jJbEeO7iqsmL-jrBA" label="X" column="_JhHoADJaEeO7iqsmL-jrBA">
-        <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
-        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
+      <cells xmi:type="table:DCell" uid="_9QpC8jJbEeO7iqsmL-jrBA" label="X" column="_JhHoADJaEeO7iqsmL-jrBA">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
         <intersectionMapping xmi:type="description_1:IntersectionMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@intersection.0"/>
       </cells>
     </lines>
-    <columns xmi:type="table:DTargetColumn" xmi:id="_JhHoADJaEeO7iqsmL-jrBA" label="Processor DSP" cells="_9QpC8jJbEeO7iqsmL-jrBA" width="65">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
+    <columns xmi:type="table:DTargetColumn" uid="_JhHoADJaEeO7iqsmL-jrBA" label="Processor DSP" cells="_9QpC8jJbEeO7iqsmL-jrBA" width="65">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:ElementColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedColumnMappings.0"/>
     </columns>
-    <columns xmi:type="table:DTargetColumn" xmi:id="_JhHoATJaEeO7iqsmL-jrBA" label="Processor Motion_Engine" cells="_9Qob4DJbEeO7iqsmL-jrBA _9Qob4jJbEeO7iqsmL-jrBA _XLQCwKUqEeerOY55FDaMag" width="115">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+    <columns xmi:type="table:DTargetColumn" uid="_JhHoATJaEeO7iqsmL-jrBA" label="Processor Motion_Engine" cells="_9Qob4DJbEeO7iqsmL-jrBA _9Qob4jJbEeO7iqsmL-jrBA _XLQCwKUqEeerOY55FDaMag" width="115">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:ElementColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedColumnMappings.0"/>
     </columns>
-    <columns xmi:type="table:DTargetColumn" xmi:id="_JhIPEDJaEeO7iqsmL-jrBA" label="Processor Radar_Capture" cells="_yH_UQDyzEeOiYdTXWoHNAg" width="116">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
+    <columns xmi:type="table:DTargetColumn" uid="_JhIPEDJaEeO7iqsmL-jrBA" label="Processor Radar_Capture" cells="_yH_UQDyzEeOiYdTXWoHNAg" width="116">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:ElementColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedColumnMappings.0"/>
     </columns>
-    <columns xmi:type="table:DTargetColumn" xmi:id="_XLONkKUqEeerOY55FDaMag" label="Processor Engine" cells="_XLPbsKUqEeerOY55FDaMag" width="133">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+    <columns xmi:type="table:DTargetColumn" uid="_XLONkKUqEeerOY55FDaMag" label="Processor Engine" cells="_XLPbsKUqEeerOY55FDaMag" width="133">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:ElementColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedColumnMappings.0"/>
     </columns>
-    <columns xmi:type="table:DTargetColumn" xmi:id="_XLONkaUqEeerOY55FDaMag" label="Processor GPU" cells="_XLQCwaUqEeerOY55FDaMag" width="120">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+    <columns xmi:type="table:DTargetColumn" uid="_XLONkaUqEeerOY55FDaMag" label="Processor GPU" cells="_XLQCwaUqEeerOY55FDaMag" width="120">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:ElementColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']/@ownedColumnMappings.0"/>
     </columns>
     <description xmi:type="description_1:CrossTableDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='matrix']"/>
   </table:DTable>
-  <table:DTable xmi:id="_jar8IDJcEeO7iqsmL-jrBA" name="Processors table" headerColumnWidth="162">
-    <target xmi:type="flow:System" href="Robot.flow#/"/>
-    <lines xmi:type="table:DLine" xmi:id="_jar8ITJcEeO7iqsmL-jrBA" label="DSP">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
+  <table:DTable uid="_jar8IDJcEeO7iqsmL-jrBA" headerColumnWidth="162">
+    <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
+    <lines xmi:type="table:DLine" uid="_jar8ITJcEeO7iqsmL-jrBA" label="DSP">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_sXhUQTJcEeO7iqsmL-jrBA" label="4" column="_sXhUQDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_pdU3MDJgEeO7iqsmL-jrBA">
+      <cells xmi:type="table:DCell" uid="_sXhUQTJcEeO7iqsmL-jrBA" label="4" column="_sXhUQDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_pdU3MDJgEeO7iqsmL-jrBA">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colCapacity']"/>
         </currentStyle>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_yQ5icDJcEeO7iqsmL-jrBA" label="40" column="_yQ47YDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_pdU3MjJgEeO7iqsmL-jrBA">
+      <cells xmi:type="table:DCell" uid="_yQ5icDJcEeO7iqsmL-jrBA" label="40" column="_yQ47YDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_pdU3MjJgEeO7iqsmL-jrBA">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colConsumption']"/>
         </currentStyle>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_2GLx8TJcEeO7iqsmL-jrBA" label="4" column="_2GLx8DJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_Ir3ToDJdEeO7iqsmL-jrBA">
+      <cells xmi:type="table:DCell" uid="_2GLx8TJcEeO7iqsmL-jrBA" label="4" column="_2GLx8DJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_Ir3ToDJdEeO7iqsmL-jrBA">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colLoad']"/>
           <backgroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colLoad']"/>
         </currentStyle>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_W-oOoDJdEeO7iqsmL-jrBA" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_lBVNADJgEeO7iqsmL-jrBA">
+      <cells xmi:type="table:DCell" uid="_W-oOoDJdEeO7iqsmL-jrBA" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_lBVNADJgEeO7iqsmL-jrBA">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colStatus']"/>
         </currentStyle>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_fBuiYTJdEeO7iqsmL-jrBA" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_fBvJcDJdEeO7iqsmL-jrBA" backgroundColor="138,226,52">
+      <cells xmi:type="table:DCell" uid="_fBuiYTJdEeO7iqsmL-jrBA" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_fBvJcDJdEeO7iqsmL-jrBA" backgroundColor="138,226,52">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colUsage']"/>
           <backgroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colUsage']"/>
         </currentStyle>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_jar8IjJcEeO7iqsmL-jrBA" label="Motion_Engine">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+    <lines xmi:type="table:DLine" uid="_jar8IjJcEeO7iqsmL-jrBA" label="Motion_Engine">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_sXh7UDJcEeO7iqsmL-jrBA" label="15" column="_sXhUQDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+      <cells xmi:type="table:DCell" uid="_sXh7UDJcEeO7iqsmL-jrBA" label="15" column="_sXhUQDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_yQ6JgDJcEeO7iqsmL-jrBA" label="150" column="_yQ47YDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+      <cells xmi:type="table:DCell" uid="_yQ6JgDJcEeO7iqsmL-jrBA" label="150" column="_yQ47YDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_2GMZADJcEeO7iqsmL-jrBA" label="18" column="_2GLx8DJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+      <cells xmi:type="table:DCell" uid="_2GMZADJcEeO7iqsmL-jrBA" label="18" column="_2GLx8DJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_W-o1sDJdEeO7iqsmL-jrBA" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+      <cells xmi:type="table:DCell" uid="_W-o1sDJdEeO7iqsmL-jrBA" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_fBvwgDJdEeO7iqsmL-jrBA" label="high" column="_fBuiYDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_mtIH0DJdEeO7iqsmL-jrBA" backgroundColor="252,175,62">
+      <cells xmi:type="table:DCell" uid="_fBvwgDJdEeO7iqsmL-jrBA" label="high" column="_fBuiYDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_mtIH0DJdEeO7iqsmL-jrBA" backgroundColor="252,175,62">
           <backgroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colUsage']"/>
         </currentStyle>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_jar8JDJcEeO7iqsmL-jrBA" label="Radar_Capture">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
+    <lines xmi:type="table:DLine" uid="_jar8JDJcEeO7iqsmL-jrBA" label="Radar_Capture">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_sXiiYTJcEeO7iqsmL-jrBA" label="10" column="_sXhUQDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_OUousD5WEeSdtMj-LVCEOA">
+      <cells xmi:type="table:DCell" uid="_sXiiYTJcEeO7iqsmL-jrBA" label="10" column="_sXhUQDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_OUousD5WEeSdtMj-LVCEOA">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colCapacity']"/>
         </currentStyle>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_yQ6wkTJcEeO7iqsmL-jrBA" label="100" column="_yQ47YDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_OUousj5WEeSdtMj-LVCEOA">
+      <cells xmi:type="table:DCell" uid="_yQ6wkTJcEeO7iqsmL-jrBA" label="100" column="_yQ47YDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_OUousj5WEeSdtMj-LVCEOA">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colConsumption']"/>
         </currentStyle>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_2GNAEDJcEeO7iqsmL-jrBA" label="8" column="_2GLx8DJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
+      <cells xmi:type="table:DCell" uid="_2GNAEDJcEeO7iqsmL-jrBA" label="8" column="_2GLx8DJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_W-qD0DJdEeO7iqsmL-jrBA" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_OUoutD5WEeSdtMj-LVCEOA">
+      <cells xmi:type="table:DCell" uid="_W-qD0DJdEeO7iqsmL-jrBA" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_OUoutD5WEeSdtMj-LVCEOA">
           <foregroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colStatus']"/>
         </currentStyle>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_fBw-oDJdEeO7iqsmL-jrBA" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_mtIu4DJdEeO7iqsmL-jrBA" backgroundColor="138,226,52">
+      <cells xmi:type="table:DCell" uid="_fBw-oDJdEeO7iqsmL-jrBA" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_mtIu4DJdEeO7iqsmL-jrBA" backgroundColor="138,226,52">
           <backgroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colUsage']"/>
         </currentStyle>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_XfmiIKUqEeerOY55FDaMag" label="Engine">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+    <lines xmi:type="table:DLine" uid="_XfmiIKUqEeerOY55FDaMag" label="Engine">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_Xfo-YKUqEeerOY55FDaMag" label="10" column="_sXhUQDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+      <cells xmi:type="table:DCell" uid="_Xfo-YKUqEeerOY55FDaMag" label="10" column="_sXhUQDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_Xfo-YaUqEeerOY55FDaMag" label="100" column="_yQ47YDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+      <cells xmi:type="table:DCell" uid="_Xfo-YaUqEeerOY55FDaMag" label="100" column="_yQ47YDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_Xfo-YqUqEeerOY55FDaMag" label="8" column="_2GLx8DJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+      <cells xmi:type="table:DCell" uid="_Xfo-YqUqEeerOY55FDaMag" label="8" column="_2GLx8DJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_XfplcKUqEeerOY55FDaMag" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+      <cells xmi:type="table:DCell" uid="_XfplcKUqEeerOY55FDaMag" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_XfplcaUqEeerOY55FDaMag" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_XfplcqUqEeerOY55FDaMag" backgroundColor="138,226,52">
+      <cells xmi:type="table:DCell" uid="_XfplcaUqEeerOY55FDaMag" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_XfplcqUqEeerOY55FDaMag" backgroundColor="138,226,52">
           <backgroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colUsage']"/>
         </currentStyle>
       </cells>
     </lines>
-    <lines xmi:type="table:DLine" xmi:id="_XfmiIaUqEeerOY55FDaMag" label="GPU">
-      <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-      <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+    <lines xmi:type="table:DLine" uid="_XfmiIaUqEeerOY55FDaMag" label="GPU">
+      <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
       <originMapping xmi:type="description_1:LineMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedLineMappings[name='lineProcessor']"/>
-      <cells xmi:type="table:DCell" xmi:id="_XfqMgKUqEeerOY55FDaMag" label="10" column="_sXhUQDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+      <cells xmi:type="table:DCell" uid="_XfqMgKUqEeerOY55FDaMag" label="10" column="_sXhUQDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_XfqMgaUqEeerOY55FDaMag" label="100" column="_yQ47YDJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+      <cells xmi:type="table:DCell" uid="_XfqMgaUqEeerOY55FDaMag" label="100" column="_yQ47YDJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_XfqMgqUqEeerOY55FDaMag" label="6" column="_2GLx8DJcEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+      <cells xmi:type="table:DCell" uid="_XfqMgqUqEeerOY55FDaMag" label="6" column="_2GLx8DJcEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_XfqMg6UqEeerOY55FDaMag" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+      <cells xmi:type="table:DCell" uid="_XfqMg6UqEeerOY55FDaMag" label="active" column="_W-nnkDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
       </cells>
-      <cells xmi:type="table:DCell" xmi:id="_XfqMhKUqEeerOY55FDaMag" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <currentStyle xmi:type="table:DCellStyle" xmi:id="_XfqMhaUqEeerOY55FDaMag" backgroundColor="138,226,52">
+      <cells xmi:type="table:DCell" uid="_XfqMhKUqEeerOY55FDaMag" label="standard" column="_fBuiYDJdEeO7iqsmL-jrBA">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <currentStyle xmi:type="table:DCellStyle" uid="_XfqMhaUqEeerOY55FDaMag" backgroundColor="138,226,52">
           <backgroundStyleOrigin xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colUsage']"/>
         </currentStyle>
       </cells>
     </lines>
-    <columns xmi:type="table:DFeatureColumn" xmi:id="_sXhUQDJcEeO7iqsmL-jrBA" label="capacity" cells="_sXhUQTJcEeO7iqsmL-jrBA _sXh7UDJcEeO7iqsmL-jrBA _sXiiYTJcEeO7iqsmL-jrBA _Xfo-YKUqEeerOY55FDaMag _XfqMgKUqEeerOY55FDaMag" width="57" featureName="capacity">
+    <columns xmi:type="table:DFeatureColumn" uid="_sXhUQDJcEeO7iqsmL-jrBA" label="capacity" cells="_sXhUQTJcEeO7iqsmL-jrBA _sXh7UDJcEeO7iqsmL-jrBA _sXiiYTJcEeO7iqsmL-jrBA _Xfo-YKUqEeerOY55FDaMag _XfqMgKUqEeerOY55FDaMag" width="57" featureName="capacity">
       <originMapping xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colCapacity']"/>
     </columns>
-    <columns xmi:type="table:DFeatureColumn" xmi:id="_yQ47YDJcEeO7iqsmL-jrBA" label="consumption" cells="_yQ5icDJcEeO7iqsmL-jrBA _yQ6JgDJcEeO7iqsmL-jrBA _yQ6wkTJcEeO7iqsmL-jrBA _Xfo-YaUqEeerOY55FDaMag _XfqMgaUqEeerOY55FDaMag" width="83" featureName="consumption">
+    <columns xmi:type="table:DFeatureColumn" uid="_yQ47YDJcEeO7iqsmL-jrBA" label="consumption" cells="_yQ5icDJcEeO7iqsmL-jrBA _yQ6JgDJcEeO7iqsmL-jrBA _yQ6wkTJcEeO7iqsmL-jrBA _Xfo-YaUqEeerOY55FDaMag _XfqMgaUqEeerOY55FDaMag" width="83" featureName="consumption">
       <originMapping xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colConsumption']"/>
     </columns>
-    <columns xmi:type="table:DFeatureColumn" xmi:id="_2GLx8DJcEeO7iqsmL-jrBA" label="load" cells="_2GLx8TJcEeO7iqsmL-jrBA _2GMZADJcEeO7iqsmL-jrBA _2GNAEDJcEeO7iqsmL-jrBA _Xfo-YqUqEeerOY55FDaMag _XfqMgqUqEeerOY55FDaMag" width="38" featureName="load">
+    <columns xmi:type="table:DFeatureColumn" uid="_2GLx8DJcEeO7iqsmL-jrBA" label="load" cells="_2GLx8TJcEeO7iqsmL-jrBA _2GMZADJcEeO7iqsmL-jrBA _2GNAEDJcEeO7iqsmL-jrBA _Xfo-YqUqEeerOY55FDaMag _XfqMgqUqEeerOY55FDaMag" width="38" featureName="load">
       <originMapping xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colLoad']"/>
     </columns>
-    <columns xmi:type="table:DFeatureColumn" xmi:id="_W-nnkDJdEeO7iqsmL-jrBA" label="status" cells="_W-oOoDJdEeO7iqsmL-jrBA _W-o1sDJdEeO7iqsmL-jrBA _W-qD0DJdEeO7iqsmL-jrBA _XfplcKUqEeerOY55FDaMag _XfqMg6UqEeerOY55FDaMag" width="46" featureName="status">
+    <columns xmi:type="table:DFeatureColumn" uid="_W-nnkDJdEeO7iqsmL-jrBA" label="status" cells="_W-oOoDJdEeO7iqsmL-jrBA _W-o1sDJdEeO7iqsmL-jrBA _W-qD0DJdEeO7iqsmL-jrBA _XfplcKUqEeerOY55FDaMag _XfqMg6UqEeerOY55FDaMag" width="46" featureName="status">
       <originMapping xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colStatus']"/>
     </columns>
-    <columns xmi:type="table:DFeatureColumn" xmi:id="_fBuiYDJdEeO7iqsmL-jrBA" label="usage" cells="_fBuiYTJdEeO7iqsmL-jrBA _fBvwgDJdEeO7iqsmL-jrBA _fBw-oDJdEeO7iqsmL-jrBA _XfplcaUqEeerOY55FDaMag _XfqMhKUqEeerOY55FDaMag" width="63" featureName="usage">
+    <columns xmi:type="table:DFeatureColumn" uid="_fBuiYDJdEeO7iqsmL-jrBA" label="usage" cells="_fBuiYTJdEeO7iqsmL-jrBA _fBvwgDJdEeO7iqsmL-jrBA _fBw-oDJdEeO7iqsmL-jrBA _XfplcaUqEeerOY55FDaMag _XfqMhKUqEeerOY55FDaMag" width="63" featureName="usage">
       <originMapping xmi:type="description_1:FeatureColumnMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']/@ownedColumnMappings[name='colUsage']"/>
     </columns>
     <description xmi:type="description_1:EditionTableDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='table']"/>
   </table:DTable>
-  <diagram:DSemanticDiagram xmi:id="_w8QSwII2EeWWPeqWzDxWOA" name="new Package dep">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_w8QSwYI2EeWWPeqWzDxWOA" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_w8QSwoI2EeWWPeqWzDxWOA"/>
+  <diagram:DSemanticDiagram uid="_w8QSwII2EeWWPeqWzDxWOA">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_w8QSwYI2EeWWPeqWzDxWOA" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_w8QSwoI2EeWWPeqWzDxWOA"/>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_w8otQII2EeWWPeqWzDxWOA" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_w8otQII2EeWWPeqWzDxWOA" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_w8otQYI2EeWWPeqWzDxWOA" type="Sirius" element="_w8QSwII2EeWWPeqWzDxWOA" measurementUnit="Pixel">
         <styles xmi:type="notation:DiagramStyle" xmi:id="_w8otQoI2EeWWPeqWzDxWOA"/>
       </data>
     </ownedAnnotationEntries>
     <description xmi:type="description_2:DiagramDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Package%20dep']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_w8QSw4I2EeWWPeqWzDxWOA"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_w8QSw4I2EeWWPeqWzDxWOA"/>
     <activatedLayers xmi:type="description_2:Layer" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Package%20dep']/@defaultLayer"/>
-    <target xmi:type="flow:System" href="Robot.flow#/"/>
+    <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram xmi:id="_mDPeQfKPEeaTM5lTgIAE1w" name="Topography - Deploy">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_mDPeQvKPEeaTM5lTgIAE1w" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_mDPeQ_KPEeaTM5lTgIAE1w">
+  <diagram:DSemanticDiagram uid="_mDPeQfKPEeaTM5lTgIAE1w">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_mDPeQvKPEeaTM5lTgIAE1w" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_mDPeQ_KPEeaTM5lTgIAE1w">
         <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_xQ_XAE9_EeeQdthcRQethQ" lineStyle="dash" targetArrow="InputClosedArrow">
           <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_green']"/>
           <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_xQ_XAU9_EeeQdthcRQethQ" showIcon="false" labelExpression="aql:self.load + '/' +  self.capacity">
-            <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_green']"/>
-          </centerLabelStyleDescription>
-        </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_xRCaVk9_EeeQdthcRQethQ">
-          <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_green']"/>
-          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_xRCaV09_EeeQdthcRQethQ" showIcon="false" labelExpression="aql:self.load + '/' +  self.capacity">
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_green']"/>
           </centerLabelStyleDescription>
         </computedStyleDescriptions>
@@ -349,31 +343,33 @@
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_orange']"/>
           </centerLabelStyleDescription>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_bjwHIE-CEeeeDdTayR14MQ">
-          <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_orange']"/>
-          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_bjwHIU-CEeeeDdTayR14MQ" showIcon="false" labelExpression="aql:self.load + '/' +  self.capacity">
-            <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_orange']"/>
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_Jfe-8DCxEeuAyprcJPTPWQ" lineStyle="dash" targetArrow="InputClosedArrow">
+          <strokeColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Green']"/>
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_Jfe-8TCxEeuAyprcJPTPWQ" showIcon="false" labelExpression="aql:self.capacity">
+            <labelColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Green']"/>
           </centerLabelStyleDescription>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:WorkspaceImageDescription" xmi:id="_N_PNgFHYEeeZptqOXqVxBg" showIcon="false" sizeComputationExpression="aql:self.sizeFromCapacity()" arcWidth="1" arcHeight="1" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg">
-          <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-          <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_JfjQYDCxEeuAyprcJPTPWQ" lineStyle="dash" targetArrow="InputClosedArrow">
+          <strokeColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Orange']"/>
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_JfjQYTCxEeuAyprcJPTPWQ" showIcon="false" labelExpression="aql:self.capacity">
+            <labelColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Orange']"/>
+          </centerLabelStyleDescription>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:WorkspaceImageDescription" xmi:id="_6Xjm0FHYEeeWuuwNQX9Okg" showIcon="false" sizeComputationExpression="aql:self.sizeFromCapacity()" arcWidth="1" arcHeight="1" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset2_standard.svg">
-          <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-          <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_Jfnh0DCxEeuAyprcJPTPWQ">
+          <strokeColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Green']"/>
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_Jfnh0TCxEeuAyprcJPTPWQ" showIcon="false" labelExpression="aql:self.capacity">
+            <labelColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Green']"/>
+          </centerLabelStyleDescription>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:WorkspaceImageDescription" xmi:id="_6XswwFHYEeeWuuwNQX9Okg" showIcon="false" sizeComputationExpression="aql:self.sizeFromCapacity()" arcWidth="1" arcHeight="1" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_standard.svg">
-          <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-          <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-        </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:WorkspaceImageDescription" xmi:id="_OqAP4KUpEeerOY55FDaMag" showIcon="false" sizeComputationExpression="aql:self.sizeFromCapacity()" arcWidth="1" arcHeight="1" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_high.svg">
-          <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
-          <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_Jfov8DCxEeuAyprcJPTPWQ">
+          <strokeColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Orange']"/>
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_Jfov8TCxEeuAyprcJPTPWQ" showIcon="false" labelExpression="aql:self.capacity">
+            <labelColor xmi:type="description:UserFixedColor" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@userColorsPalettes[name='FlowColors']/@entries[name='Flow_Orange']"/>
+          </centerLabelStyleDescription>
         </computedStyleDescriptions>
       </data>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_mDiZMPKPEeaTM5lTgIAE1w" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_mDiZMPKPEeaTM5lTgIAE1w" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_mDiZMfKPEeaTM5lTgIAE1w" type="Sirius" element="_mDPeQfKPEeaTM5lTgIAE1w" measurementUnit="Pixel">
         <children xmi:type="notation:Node" xmi:id="_mDrjIPKPEeaTM5lTgIAE1w" type="2001" element="_mDPeRfKPEeaTM5lTgIAE1w">
           <children xmi:type="notation:Node" xmi:id="_mD1UIPKPEeaTM5lTgIAE1w" type="5002">
@@ -393,9 +389,9 @@
               <children xmi:type="notation:Node" xmi:id="_mEIPJPKPEeaTM5lTgIAE1w" type="5003">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_mEIPJfKPEeaTM5lTgIAE1w" x="-5" y="-21"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_6YQKYFHYEeeWuuwNQX9Okg" type="3005" element="_6XnRMFHYEeeWuuwNQX9Okg">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_6YQKYVHYEeeWuuwNQX9Okg" fontName="Sans Serif"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6YQKYlHYEeeWuuwNQX9Okg"/>
+              <children xmi:type="notation:Node" xmi:id="_o38FADCwEeuiOLVpQO2TvQ" type="3005" element="_osNWIDCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o38FATCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o38FAjCwEeuiOLVpQO2TvQ"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_mEIPIvKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mEIPI_KPEeaTM5lTgIAE1w" x="19" y="49" width="40" height="40"/>
@@ -404,26 +400,37 @@
               <children xmi:type="notation:Node" xmi:id="_mHQbk_KPEeaTM5lTgIAE1w" type="5003">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_mHQblPKPEeaTM5lTgIAE1w" y="-21"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_OqFvcKUpEeerOY55FDaMag" type="3005" element="_OqAP4aUpEeerOY55FDaMag">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_OqFvcaUpEeerOY55FDaMag" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OqFvcqUpEeerOY55FDaMag"/>
+              <children xmi:type="notation:Node" xmi:id="_o396MDCwEeuiOLVpQO2TvQ" type="3005" element="_osRAgTCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o396MTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o396MjCwEeuiOLVpQO2TvQ"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_mHQbkfKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mHQbkvKPEeaTM5lTgIAE1w" x="125" y="39" width="100" height="100"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_UWT-IE-EEeeeZ8j7YmiDCQ" visible="false" type="3007" element="_UV35QE-EEeeeZ8j7YmiDCQ">
-              <children xmi:type="notation:Node" xmi:id="_UWb58E-EEeeeZ8j7YmiDCQ" type="5003">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_UWb58U-EEeeeZ8j7YmiDCQ" y="-21"/>
+            <children xmi:type="notation:Node" xmi:id="_o20qsDCwEeuiOLVpQO2TvQ" type="3007" element="_osTcwDCwEeuiOLVpQO2TvQ">
+              <children xmi:type="notation:Node" xmi:id="_o22f4DCwEeuiOLVpQO2TvQ" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_o22f4TCwEeuiOLVpQO2TvQ" y="-14"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_UWqjcE-EEeeeZ8j7YmiDCQ" type="3005" element="_UV35QU-EEeeeZ8j7YmiDCQ">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_UWqjcU-EEeeeZ8j7YmiDCQ" fontName="Sans Serif"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UWqjck-EEeeeZ8j7YmiDCQ"/>
+              <children xmi:type="notation:Node" xmi:id="_o3_IUDCwEeuiOLVpQO2TvQ" type="3005" element="_osUD0DCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o3_IUTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o3_IUjCwEeuiOLVpQO2TvQ"/>
               </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_UWT-IU-EEeeeZ8j7YmiDCQ" fontName="Sans Serif" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UWT-Ik-EEeeeZ8j7YmiDCQ" x="195" y="63" width="60" height="60"/>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_o20qsTCwEeuiOLVpQO2TvQ" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o20qsjCwEeuiOLVpQO2TvQ" x="225" y="-17" width="30" height="30"/>
             </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_mEIPFfKPEeaTM5lTgIAE1w"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_mEIPFvKPEeaTM5lTgIAE1w"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_ot2U4DCwEeuiOLVpQO2TvQ" type="3012" element="_or4mADCwEeuiOLVpQO2TvQ">
+            <children xmi:type="notation:Node" xmi:id="_ouDJMDCwEeuiOLVpQO2TvQ" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ouDJMTCwEeuiOLVpQO2TvQ" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_o4AWcDCwEeuiOLVpQO2TvQ" type="3005" element="_or83cDCwEeuiOLVpQO2TvQ">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_o4AWcTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o4AWcjCwEeuiOLVpQO2TvQ"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_ot2U4TCwEeuiOLVpQO2TvQ" fontName="Segoe UI" fontHeight="12"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ot2U4jCwEeuiOLVpQO2TvQ" x="-22" width="30" height="30"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_mEIPEfKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="10" bold="true" italic="true"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mEIPEvKPEeaTM5lTgIAE1w" x="20" y="20"/>
@@ -435,14 +442,14 @@
               <children xmi:type="notation:Node" xmi:id="_mHtHgPKPEeaTM5lTgIAE1w" type="5003">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_mHtHgfKPEeaTM5lTgIAE1w" y="-21"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_OAMPwFHYEeeZptqOXqVxBg" type="3005" element="_N_WiQFHYEeeZptqOXqVxBg">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_OAMPwVHYEeeZptqOXqVxBg" fontName="Sans Serif"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OAMPwlHYEeeZptqOXqVxBg"/>
+              <children xmi:type="notation:Node" xmi:id="_o7a20DCwEeuiOLVpQO2TvQ" type="3005" element="_oseb4DCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o7a20TCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7a20jCwEeuiOLVpQO2TvQ"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_mHj9nPKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mHj9nfKPEeaTM5lTgIAE1w" x="130" y="29" width="60" height="60"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_mHtHh_KPEeaTM5lTgIAE1w" type="3007" element="_mDPeVfKPEeaTM5lTgIAE1w">
+            <children xmi:type="notation:Node" xmi:id="_mHtHh_KPEeaTM5lTgIAE1w" visible="false" type="3007" element="_mDPeVfKPEeaTM5lTgIAE1w">
               <children xmi:type="notation:Node" xmi:id="_mHtHivKPEeaTM5lTgIAE1w" type="5003">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_mHtHi_KPEeaTM5lTgIAE1w" x="-18" y="41"/>
               </children>
@@ -453,7 +460,7 @@
               <styles xmi:type="notation:ShapeStyle" xmi:id="_mHtHiPKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mHtHifKPEeaTM5lTgIAE1w" x="100" y="234" width="100" height="100"/>
             </children>
-            <children xmi:type="notation:Node" xmi:id="_mHtHjPKPEeaTM5lTgIAE1w" type="3007" element="_mDPeV_KPEeaTM5lTgIAE1w">
+            <children xmi:type="notation:Node" xmi:id="_mHtHjPKPEeaTM5lTgIAE1w" visible="false" type="3007" element="_mDPeV_KPEeaTM5lTgIAE1w">
               <children xmi:type="notation:Node" xmi:id="_mHtHj_KPEeaTM5lTgIAE1w" type="5003">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_mHtHkPKPEeaTM5lTgIAE1w" x="31"/>
               </children>
@@ -468,43 +475,76 @@
               <children xmi:type="notation:Node" xmi:id="_WQWB4E-EEeeeZ8j7YmiDCQ" type="5003">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_WQWB4U-EEeeeZ8j7YmiDCQ" y="-21"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_6YXfIFHYEeeWuuwNQX9Okg" type="3005" element="_6XswwVHYEeeWuuwNQX9Okg">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_6YXfIVHYEeeWuuwNQX9Okg" fontName="Sans Serif"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_6YXfIlHYEeeWuuwNQX9Okg"/>
+              <children xmi:type="notation:Node" xmi:id="_o7d6IDCwEeuiOLVpQO2TvQ" type="3005" element="_osgRETCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o7d6ITCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7d6IjCwEeuiOLVpQO2TvQ"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_WQVa0U-EEeeeZ8j7YmiDCQ" fontName="Sans Serif" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_WQVa0k-EEeeeZ8j7YmiDCQ" x="370" y="29" width="60" height="60"/>
-            </children>
-            <children xmi:type="notation:Node" xmi:id="_Xh6-gE-EEeeeZ8j7YmiDCQ" visible="false" type="3007" element="_Xhx0kE-EEeeeZ8j7YmiDCQ">
-              <children xmi:type="notation:Node" xmi:id="_Xh7lkE-EEeeeZ8j7YmiDCQ" type="5003">
-                <layoutConstraint xmi:type="notation:Location" xmi:id="_Xh7lkU-EEeeeZ8j7YmiDCQ" y="-21"/>
-              </children>
-              <children xmi:type="notation:Node" xmi:id="_Xh8MoE-EEeeeZ8j7YmiDCQ" type="3005" element="_Xhx0kU-EEeeeZ8j7YmiDCQ">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_Xh8MoU-EEeeeZ8j7YmiDCQ" fontName="Sans Serif"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Xh8Mok-EEeeeZ8j7YmiDCQ"/>
-              </children>
-              <styles xmi:type="notation:ShapeStyle" xmi:id="_Xh6-gU-EEeeeZ8j7YmiDCQ" fontName="Sans Serif" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Xh6-gk-EEeeeZ8j7YmiDCQ" x="465" y="249" width="60" height="60"/>
             </children>
             <children xmi:type="notation:Node" xmi:id="_fzr1oFHPEeeDkqQkk8TPzg" type="3007" element="_fzXFgFHPEeeDkqQkk8TPzg">
               <children xmi:type="notation:Node" xmi:id="_fzzxcFHPEeeDkqQkk8TPzg" type="5003">
                 <layoutConstraint xmi:type="notation:Location" xmi:id="_fzzxcVHPEeeDkqQkk8TPzg" y="-21"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_889b0KUnEeerOY55FDaMag" type="3005" element="_88zDwKUnEeerOY55FDaMag">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_889b0aUnEeerOY55FDaMag" fontName="Segoe UI"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_889b0qUnEeerOY55FDaMag"/>
+              <children xmi:type="notation:Node" xmi:id="_o7fIQDCwEeuiOLVpQO2TvQ" type="3005" element="_osmXsDCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o7fIQTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7fIQjCwEeuiOLVpQO2TvQ"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_fzr1oVHPEeeDkqQkk8TPzg" fontName="Sans Serif" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fzr1olHPEeeDkqQkk8TPzg" x="51" y="119" width="100" height="100"/>
             </children>
+            <children xmi:type="notation:Node" xmi:id="_o45HQDCwEeuiOLVpQO2TvQ" type="3007" element="_osoM4DCwEeuiOLVpQO2TvQ">
+              <children xmi:type="notation:Node" xmi:id="_o468cDCwEeuiOLVpQO2TvQ" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_o468cTCwEeuiOLVpQO2TvQ" x="-3" y="-14"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_o7fvUDCwEeuiOLVpQO2TvQ" type="3005" element="_ospbADCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o7fvUTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7fvUjCwEeuiOLVpQO2TvQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_o45HQTCwEeuiOLVpQO2TvQ" fontColor="3943168" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o45HQjCwEeuiOLVpQO2TvQ" x="240" y="99" width="60" height="60"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_o5xRADCwEeuiOLVpQO2TvQ" type="3007" element="_osqpITCwEeuiOLVpQO2TvQ">
+              <children xmi:type="notation:Node" xmi:id="_o5x4EDCwEeuiOLVpQO2TvQ" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_o5x4ETCwEeuiOLVpQO2TvQ" y="-14"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_o7g9cDCwEeuiOLVpQO2TvQ" type="3005" element="_osseUDCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o7g9cTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7g9cjCwEeuiOLVpQO2TvQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_o5xRATCwEeuiOLVpQO2TvQ" fontColor="3943168" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o5xRAjCwEeuiOLVpQO2TvQ" x="100" y="219" width="80" height="80"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_o66ggDCwEeuiOLVpQO2TvQ" type="3007" element="_osu6kDCwEeuiOLVpQO2TvQ">
+              <children xmi:type="notation:Node" xmi:id="_o67uoDCwEeuiOLVpQO2TvQ" type="5003">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_o67uoTCwEeuiOLVpQO2TvQ" x="-6" y="1"/>
+              </children>
+              <children xmi:type="notation:Node" xmi:id="_o7iLkDCwEeuiOLVpQO2TvQ" type="3005" element="_osvhoDCwEeuiOLVpQO2TvQ">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_o7iLkTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7iLkjCwEeuiOLVpQO2TvQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_o66ggTCwEeuiOLVpQO2TvQ" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o66ggjCwEeuiOLVpQO2TvQ" x="30" y="29" width="0" height="0"/>
+            </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_mEIPHPKPEeaTM5lTgIAE1w"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_mEIPHfKPEeaTM5lTgIAE1w"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_o4BkkDCwEeuiOLVpQO2TvQ" type="3012" element="_osWgEDCwEeuiOLVpQO2TvQ">
+            <children xmi:type="notation:Node" xmi:id="_o4DZwDCwEeuiOLVpQO2TvQ" type="5010">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_o4DZwTCwEeuiOLVpQO2TvQ" y="5"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_o7jZsDCwEeuiOLVpQO2TvQ" type="3005" element="_osXHIDCwEeuiOLVpQO2TvQ">
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_o7jZsTCwEeuiOLVpQO2TvQ" fontName="Segoe UI"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7jZsjCwEeuiOLVpQO2TvQ"/>
+            </children>
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_o4BkkTCwEeuiOLVpQO2TvQ" fontName="Segoe UI" fontHeight="12"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o4BkkjCwEeuiOLVpQO2TvQ" x="-22" width="30" height="30"/>
           </children>
           <styles xmi:type="notation:ShapeStyle" xmi:id="_mEIPGPKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="10" bold="true" italic="true"/>
           <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mEIPGfKPEeaTM5lTgIAE1w" x="275" y="20" width="553" height="358"/>
         </children>
         <styles xmi:type="notation:DiagramStyle" xmi:id="_mDiZMvKPEeaTM5lTgIAE1w"/>
-        <edges xmi:type="notation:Edge" xmi:id="_mIApjvKPEeaTM5lTgIAE1w" type="4001" element="_mDPeX_KPEeaTM5lTgIAE1w" source="_mHtHjPKPEeaTM5lTgIAE1w" target="_mHj9m_KPEeaTM5lTgIAE1w">
+        <edges xmi:type="notation:Edge" xmi:id="_mIApjvKPEeaTM5lTgIAE1w" visible="false" type="4001" element="_mDPeX_KPEeaTM5lTgIAE1w" source="_mHtHjPKPEeaTM5lTgIAE1w" target="_mHj9m_KPEeaTM5lTgIAE1w">
           <children xmi:type="notation:Node" xmi:id="_mIApkvKPEeaTM5lTgIAE1w" type="6001">
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mIApk_KPEeaTM5lTgIAE1w" x="-27" y="-32"/>
           </children>
@@ -532,7 +572,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_mIApm_KPEeaTM5lTgIAE1w"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_mIApnPKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mIApnfKPEeaTM5lTgIAE1w" points="[2, -20, -7, 120]$[13, -123, 4, 17]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mIApnfKPEeaTM5lTgIAE1w" points="[0, -20, -4, 126]$[3, -126, -1, 20]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIAppPKPEeaTM5lTgIAE1w" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIAppfKPEeaTM5lTgIAE1w" id="(0.5,0.5)"/>
         </edges>
@@ -548,7 +588,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_mIApp_KPEeaTM5lTgIAE1w"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_mIApqPKPEeaTM5lTgIAE1w" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mIApqfKPEeaTM5lTgIAE1w" points="[17, 11, -99, -39]$[86, 38, -30, -12]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_mIApqfKPEeaTM5lTgIAE1w" points="[0, 0, -136, -90]$[136, 90, 0, 0]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIApsPKPEeaTM5lTgIAE1w" id="(0.5,0.0)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_mIApsfKPEeaTM5lTgIAE1w" id="(0.5,1.0)"/>
         </edges>
@@ -580,11 +620,11 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_i1mHcVHPEeeDkqQkk8TPzg"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_i1mHclHPEeeDkqQkk8TPzg" fontColor="1345869" fontName="Sans Serif" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i1mHc1HPEeeDkqQkk8TPzg" points="[0, 0, 111, 38]$[-112, -38, -1, 0]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_i1mHc1HPEeeDkqQkk8TPzg" points="[0, 0, 81, 30]$[-81, -30, 0, 0]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i1mugFHPEeeDkqQkk8TPzg" id="(0.0,0.33333333333333326)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_i1mugVHPEeeDkqQkk8TPzg" id="(1.0,0.8333333333333334)"/>
         </edges>
-        <edges xmi:type="notation:Edge" xmi:id="_faruIFZhEee55OSk-vC-7w" type="4001" element="_fakZYFZhEee55OSk-vC-7w" source="_mHtHh_KPEeaTM5lTgIAE1w" target="_fzr1oFHPEeeDkqQkk8TPzg">
+        <edges xmi:type="notation:Edge" xmi:id="_faruIFZhEee55OSk-vC-7w" visible="false" type="4001" element="_fakZYFZhEee55OSk-vC-7w" source="_mHtHh_KPEeaTM5lTgIAE1w" target="_fzr1oFHPEeeDkqQkk8TPzg">
           <children xmi:type="notation:Node" xmi:id="_faruJFZhEee55OSk-vC-7w" type="6001">
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_faruJVZhEee55OSk-vC-7w" y="-10"/>
           </children>
@@ -596,7 +636,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_faruIVZhEee55OSk-vC-7w"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_faruIlZhEee55OSk-vC-7w" fontColor="1345869" fontName="Sans Serif" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_faruI1ZhEee55OSk-vC-7w" points="[375, 254, 375, 254]$[326, 139, 326, 139]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_faruI1ZhEee55OSk-vC-7w" points="[-22, -50, 27, 65]$[-28, -65, 21, 50]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fasVMFZhEee55OSk-vC-7w" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fasVMVZhEee55OSk-vC-7w" id="(0.5,0.5)"/>
         </edges>
@@ -612,200 +652,310 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_fasVM1ZhEee55OSk-vC-7w"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_fasVNFZhEee55OSk-vC-7w" fontColor="230880" fontName="Sans Serif" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fasVNVZhEee55OSk-vC-7w" points="[405, 49, 405, 49]$[645, 49, 645, 49]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_fasVNVZhEee55OSk-vC-7w" points="[30, 0, -210, 0]$[210, 0, -30, 0]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fas8QFZhEee55OSk-vC-7w" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_fas8QVZhEee55OSk-vC-7w" id="(0.5,0.5)"/>
         </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_o7qHYDCwEeuiOLVpQO2TvQ" type="4001" element="_otIjMDCwEeuiOLVpQO2TvQ" source="_o45HQDCwEeuiOLVpQO2TvQ" target="_fzr1oFHPEeeDkqQkk8TPzg">
+          <children xmi:type="notation:Node" xmi:id="_o7yDMDCwEeuiOLVpQO2TvQ" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7yDMTCwEeuiOLVpQO2TvQ" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_o7zRUDCwEeuiOLVpQO2TvQ" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o7zRUTCwEeuiOLVpQO2TvQ" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_o70fcDCwEeuiOLVpQO2TvQ" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o70fcTCwEeuiOLVpQO2TvQ" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_o7qucDCwEeuiOLVpQO2TvQ"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_o7qucTCwEeuiOLVpQO2TvQ" fontColor="12762190" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_o7qucjCwEeuiOLVpQO2TvQ" points="[0, 0, 0, 60]$[0, -60, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o7_ekDCwEeuiOLVpQO2TvQ" id="(0.5,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o7_ekTCwEeuiOLVpQO2TvQ" id="(0.5,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_o8AFoDCwEeuiOLVpQO2TvQ" type="4001" element="_otLmgDCwEeuiOLVpQO2TvQ" source="_o5xRADCwEeuiOLVpQO2TvQ" target="_mHj9m_KPEeaTM5lTgIAE1w">
+          <children xmi:type="notation:Node" xmi:id="_o8AssDCwEeuiOLVpQO2TvQ" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o8BTwDCwEeuiOLVpQO2TvQ" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_o8B60DCwEeuiOLVpQO2TvQ" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o8B60TCwEeuiOLVpQO2TvQ" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_o8B60jCwEeuiOLVpQO2TvQ" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o8B60zCwEeuiOLVpQO2TvQ" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_o8AFoTCwEeuiOLVpQO2TvQ"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_o8AFojCwEeuiOLVpQO2TvQ" fontColor="42747" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_o8AFozCwEeuiOLVpQO2TvQ" points="[0, 0, 0, 60]$[0, -60, 0, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o8DI8DCwEeuiOLVpQO2TvQ" id="(0.5,0.0)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o8DwADCwEeuiOLVpQO2TvQ" id="(0.5,1.0)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_o8DwATCwEeuiOLVpQO2TvQ" type="4001" element="_otcsQDCwEeuiOLVpQO2TvQ" source="_ot2U4DCwEeuiOLVpQO2TvQ" target="_o4BkkDCwEeuiOLVpQO2TvQ">
+          <children xmi:type="notation:Node" xmi:id="_o8EXEDCwEeuiOLVpQO2TvQ" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o8EXETCwEeuiOLVpQO2TvQ" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_o8EXEjCwEeuiOLVpQO2TvQ" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o8EXEzCwEeuiOLVpQO2TvQ" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_o8E-IDCwEeuiOLVpQO2TvQ" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o8E-ITCwEeuiOLVpQO2TvQ" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_o8DwAjCwEeuiOLVpQO2TvQ"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_o8DwAzCwEeuiOLVpQO2TvQ" fontName="Segoe UI" fontHeight="8"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_o8DwBDCwEeuiOLVpQO2TvQ" points="[15, 0, -240, 0]$[240, 0, -15, 0]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o8FlMDCwEeuiOLVpQO2TvQ" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_o8FlMTCwEeuiOLVpQO2TvQ" id="(0.5,0.5)"/>
+        </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_mDPeRfKPEeaTM5lTgIAE1w" name="Wifi : 4" outgoingEdges="_mDPeYvKPEeaTM5lTgIAE1w" width="4" height="4">
-      <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
-      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_mDPeRfKPEeaTM5lTgIAE1w" name="Wifi" outgoingEdges="_mDPeYvKPEeaTM5lTgIAE1w" width="4" height="4">
+      <target xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_mDPeRvKPEeaTM5lTgIAE1w" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/antenna.svg">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_mDPeRvKPEeaTM5lTgIAE1w" showIcon="false" labelColor="0,43,60" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/antenna.svg">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']/@conditionnalStyles.2/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_mDPeR_KPEeaTM5lTgIAE1w" name="Central_Unit">
-      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.0"/>
-      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.0"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_mDPeR_KPEeaTM5lTgIAE1w" name="Central_Unit">
+      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#_74hOgLTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#_74hOgLTZEeeolunnT_MYFg"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_or4mADCwEeuiOLVpQO2TvQ" outgoingEdges="_otcsQDCwEeuiOLVpQO2TvQ" width="3" height="3" resizeKind="NSEW">
+        <target xmi:type="flow:PowerOutput" href="Robot.flow#_74k44bTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:PowerOutput" href="Robot.flow#_74k44bTZEeeolunnT_MYFg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_or83cDCwEeuiOLVpQO2TvQ" labelSize="12" showIcon="false" labelPosition="node" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/power_output.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@borderedNodeMappings[name='PowerOutputNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@borderedNodeMappings[name='PowerOutputNode']"/>
+      </ownedBorderedNodes>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_kiHeYE-EEeeeZ8j7YmiDCQ" labelSize="10" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136" backgroundStyle="Liquid" foregroundColor="243,243,243">
-        <labelFormat>italic</labelFormat>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kiHeYE-EEeeeZ8j7YmiDCQ" labelSize="10" showIcon="false" labelColor="0,43,60" borderSize="1" borderSizeComputationExpression="1" borderColor="177,188,190" backgroundStyle="Liquid" backgroundColor="240,240,240" foregroundColor="240,240,240">
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:ContainerMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_mDPeSfKPEeaTM5lTgIAE1w" name="DSP" outgoingEdges="_mDPeZfKPEeaTM5lTgIAE1w" incomingEdges="_mDPeYvKPEeaTM5lTgIAE1w" width="4" height="4">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_mDPeSfKPEeaTM5lTgIAE1w" name="DSP" outgoingEdges="_mDPeZfKPEeaTM5lTgIAE1w" incomingEdges="_mDPeYvKPEeaTM5lTgIAE1w" width="4" height="4">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_6XnRMFHYEeeWuuwNQX9Okg" showIcon="false" description="_6Xjm0FHYEeeWuuwNQX9Okg" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset2_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osNWIDCwEeuiOLVpQO2TvQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_standard.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']/@conditionnalStyles.7/@style"/>
+        </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_mDPeS_KPEeaTM5lTgIAE1w" name="Motion_Engine" incomingEdges="_mDPeZfKPEeaTM5lTgIAE1w _mDPea_KPEeaTM5lTgIAE1w _i1ZTIFHPEeeDkqQkk8TPzg" width="7" height="7">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_mDPeS_KPEeaTM5lTgIAE1w" name="Motion_Engine" incomingEdges="_mDPeZfKPEeaTM5lTgIAE1w _mDPea_KPEeaTM5lTgIAE1w _i1ZTIFHPEeeDkqQkk8TPzg" width="7" height="7">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_OqAP4aUpEeerOY55FDaMag" showIcon="false" description="_OqAP4KUpEeerOY55FDaMag" borderColor="30,30,30" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_high.svg">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osRAgTCwEeuiOLVpQO2TvQ" showIcon="false" borderColor="30,30,30" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset2_high.svg">
           <customFeatures>borderColor</customFeatures>
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']/@conditionnalStyles.3/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_UV35QE-EEeeeZ8j7YmiDCQ" name="1000" visible="false" width="6" height="6" resizeKind="NSEW">
-        <target xmi:type="flow:Fan" href="Robot.flow#//@elements.0/@elements.2"/>
-        <semanticElements xmi:type="flow:Fan" href="Robot.flow#//@elements.0/@elements.2"/>
-        <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
-        <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
-        <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_UV35QU-EEeeeZ8j7YmiDCQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
-          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']/@style"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_osTcwDCwEeuiOLVpQO2TvQ" name="100" width="3" height="3">
+        <target xmi:type="flow:Fan" href="Robot.flow#_74k44LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Fan" href="Robot.flow#_74k44LTZEeeolunnT_MYFg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osUD0DCwEeuiOLVpQO2TvQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Fan']/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']"/>
+        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Fan']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_mDPeTfKPEeaTM5lTgIAE1w" name="CaptureSubSystem">
-      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.1"/>
-      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.1"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_mDPeTfKPEeaTM5lTgIAE1w" name="CaptureSubSystem">
+      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#_74lf8bTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#_74lf8bTZEeeolunnT_MYFg"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_osWgEDCwEeuiOLVpQO2TvQ" incomingEdges="_otcsQDCwEeuiOLVpQO2TvQ" width="3" height="3" resizeKind="NSEW">
+        <target xmi:type="flow:PowerInput" href="Robot.flow#_74muFLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:PowerInput" href="Robot.flow#_74muFLTZEeeolunnT_MYFg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osXHIDCwEeuiOLVpQO2TvQ" labelSize="12" showIcon="false" labelPosition="node" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/power_input.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@borderedNodeMappings[name='PowerInputNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@borderedNodeMappings[name='PowerInputNode']"/>
+      </ownedBorderedNodes>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_kiHeYU-EEeeeZ8j7YmiDCQ" labelSize="10" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136" backgroundStyle="Liquid" foregroundColor="243,243,243">
-        <labelFormat>italic</labelFormat>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_kiHeYU-EEeeeZ8j7YmiDCQ" labelSize="10" showIcon="false" labelColor="0,43,60" borderSize="1" borderSizeComputationExpression="1" borderColor="177,188,190" backgroundStyle="Liquid" backgroundColor="240,240,240" foregroundColor="240,240,240">
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:ContainerMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_mDPeUfKPEeaTM5lTgIAE1w" name="Radar_Capture" outgoingEdges="_mDPea_KPEeaTM5lTgIAE1w _fam1oFZhEee55OSk-vC-7w" incomingEdges="_mDPeX_KPEeaTM5lTgIAE1w" width="6" height="6">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_mDPeUfKPEeaTM5lTgIAE1w" name="Radar_Capture" outgoingEdges="_mDPea_KPEeaTM5lTgIAE1w _fam1oFZhEee55OSk-vC-7w" incomingEdges="_mDPeX_KPEeaTM5lTgIAE1w _otLmgDCwEeuiOLVpQO2TvQ" width="6" height="6">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_N_WiQFHYEeeZptqOXqVxBg" showIcon="false" description="_N_PNgFHYEeeZptqOXqVxBg" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_oseb4DCwEeuiOLVpQO2TvQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']/@conditionnalStyles.12/@style"/>
+        </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_WQEVEE-EEeeeZ8j7YmiDCQ" name="Engine" incomingEdges="_fam1oFZhEee55OSk-vC-7w" width="6" height="6">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_WQEVEE-EEeeeZ8j7YmiDCQ" name="Engine" incomingEdges="_fam1oFZhEee55OSk-vC-7w" width="6" height="6">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_6XswwVHYEeeWuuwNQX9Okg" showIcon="false" description="_6XswwFHYEeeWuuwNQX9Okg" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osgRETCwEeuiOLVpQO2TvQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset2_standard.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_fzXFgFHPEeeDkqQkk8TPzg" name="GPU" outgoingEdges="_i1ZTIFHPEeeDkqQkk8TPzg" incomingEdges="_fakZYFZhEee55OSk-vC-7w" width="6" height="6">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_fzXFgFHPEeeDkqQkk8TPzg" name="GPU" outgoingEdges="_i1ZTIFHPEeeDkqQkk8TPzg" incomingEdges="_fakZYFZhEee55OSk-vC-7w _otIjMDCwEeuiOLVpQO2TvQ" width="6" height="6">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_88zDwKUnEeerOY55FDaMag" showIcon="false" description="_N_PNgFHYEeeZptqOXqVxBg" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osmXsDCwEeuiOLVpQO2TvQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']/@conditionnalStyles.12/@style"/>
+        </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_mDPeVfKPEeaTM5lTgIAE1w" name="Back_Camera : 6" outgoingEdges="_fakZYFZhEee55OSk-vC-7w" width="6" height="6">
-        <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
-        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_mDPeVfKPEeaTM5lTgIAE1w" name="Back_Camera : 6" visible="false" outgoingEdges="_fakZYFZhEee55OSk-vC-7w" width="6" height="6">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_mDPeVvKPEeaTM5lTgIAE1w" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/camera.svg">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_mDPeVvKPEeaTM5lTgIAE1w" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/camera.svg">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']/@conditionnalStyles.0/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_mDPeV_KPEeaTM5lTgIAE1w" name="Radar : 8" outgoingEdges="_mDPeX_KPEeaTM5lTgIAE1w" width="8" height="8">
-        <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
-        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_mDPeV_KPEeaTM5lTgIAE1w" name="Radar : 8" visible="false" outgoingEdges="_mDPeX_KPEeaTM5lTgIAE1w" width="8" height="8">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_mDPeWPKPEeaTM5lTgIAE1w" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/radar.svg">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_mDPeWPKPEeaTM5lTgIAE1w" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/radar.svg">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']/@conditionnalStyles.1/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_Xhx0kE-EEeeeZ8j7YmiDCQ" name="200" visible="false" width="6" height="6" resizeKind="NSEW">
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_Xhx0kU-EEeeeZ8j7YmiDCQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
-          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']/@style"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_osoM4DCwEeuiOLVpQO2TvQ" name="Back_Camera" outgoingEdges="_otIjMDCwEeuiOLVpQO2TvQ" width="6" height="6">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ospbADCwEeuiOLVpQO2TvQ" showIcon="false" labelColor="0,43,60" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/camera.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Data%20Source']/@conditionnalStyles.0/@style"/>
         </ownedStyle>
-        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']"/>
+        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Data%20Source']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_osqpITCwEeuiOLVpQO2TvQ" name="Radar" outgoingEdges="_otLmgDCwEeuiOLVpQO2TvQ" width="8" height="8">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osseUDCwEeuiOLVpQO2TvQ" showIcon="false" labelColor="0,43,60" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/radar.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Data%20Source']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Data%20Source']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_osu6kDCwEeuiOLVpQO2TvQ" name="20" width="0" height="0">
+        <target xmi:type="flow:Fan" href="Robot.flow#_74muE7TZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Fan" href="Robot.flow#_74muE7TZEeeolunnT_MYFg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_osvhoDCwEeuiOLVpQO2TvQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
+          <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Fan']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_2:NodeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Fan']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_mDPeX_KPEeaTM5lTgIAE1w" name="8/6" sourceNode="_mDPeV_KPEeaTM5lTgIAE1w" targetNode="_mDPeUfKPEeaTM5lTgIAE1w">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.2/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.2/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_bju5Ak-CEeeeDdTayR14MQ" description="_bju5AE-CEeeeDdTayR14MQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="224,133,3">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_bju5A0-CEeeeDdTayR14MQ" showIcon="false" labelColor="224,133,3"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_mDPeX_KPEeaTM5lTgIAE1w" name="8/6" visible="false" sourceNode="_mDPeV_KPEeaTM5lTgIAE1w" targetNode="_mDPeUfKPEeaTM5lTgIAE1w">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74mHA7TZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74mHA7TZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_bju5Ak-CEeeeDdTayR14MQ" description="_bju5AE-CEeeeDdTayR14MQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="224,133,3">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_bju5A0-CEeeeDdTayR14MQ" showIcon="false" labelColor="224,133,3"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_mDPeYvKPEeaTM5lTgIAE1w" name="4/4" sourceNode="_mDPeRfKPEeaTM5lTgIAE1w" targetNode="_mDPeSfKPEeaTM5lTgIAE1w">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.2/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.2/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_xRBzQk9_EeeQdthcRQethQ" description="_xQ_XAE9_EeeQdthcRQethQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_xRBzQ09_EeeQdthcRQethQ" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_mDPeYvKPEeaTM5lTgIAE1w" name="4" sourceNode="_mDPeRfKPEeaTM5lTgIAE1w" targetNode="_mDPeSfKPEeaTM5lTgIAE1w">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74muFrTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74muFrTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_JfkegDCxEeuAyprcJPTPWQ" description="_Jfe-8DCxEeuAyprcJPTPWQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="78,188,194">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_JfkegTCxEeuAyprcJPTPWQ" showIcon="false" labelColor="78,188,194"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_mDPeZfKPEeaTM5lTgIAE1w" name="4/10" sourceNode="_mDPeSfKPEeaTM5lTgIAE1w" targetNode="_mDPeS_KPEeaTM5lTgIAE1w">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.0/@elements.0/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.0/@elements.0/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_PpAzcE-CEeeeDdTayR14MQ" description="_xRCaVk9_EeeQdthcRQethQ" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_PpAzcU-CEeeeDdTayR14MQ" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_mDPeZfKPEeaTM5lTgIAE1w" name="10" sourceNode="_mDPeSfKPEeaTM5lTgIAE1w" targetNode="_mDPeS_KPEeaTM5lTgIAE1w">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74jDsLTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74jDsLTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_Jfnh0jCxEeuAyprcJPTPWQ" description="_Jfnh0DCxEeuAyprcJPTPWQ" strokeColor="78,188,194">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_Jfnh0zCxEeuAyprcJPTPWQ" showIcon="false" labelColor="78,188,194"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_mDPea_KPEeaTM5lTgIAE1w" name="8/6" sourceNode="_mDPeUfKPEeaTM5lTgIAE1w" targetNode="_mDPeS_KPEeaTM5lTgIAE1w">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_bjwHIk-CEeeeDdTayR14MQ" description="_bjwHIE-CEeeeDdTayR14MQ" routingStyle="manhattan" strokeColor="224,133,3">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_mDPea_KPEeaTM5lTgIAE1w" name="6" sourceNode="_mDPeUfKPEeaTM5lTgIAE1w" targetNode="_mDPeS_KPEeaTM5lTgIAE1w">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74lf87TZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74lf87TZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_JfpXADCxEeuAyprcJPTPWQ" description="_Jfov8DCxEeuAyprcJPTPWQ" routingStyle="manhattan" strokeColor="251,166,0">
         <customFeatures>routingStyle</customFeatures>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_bjwHI0-CEeeeDdTayR14MQ" showIcon="false" labelColor="224,133,3"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_JfpXATCxEeuAyprcJPTPWQ" showIcon="false" labelColor="251,166,0"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_i1ZTIFHPEeeDkqQkk8TPzg" name="6/10" sourceNode="_fzXFgFHPEeeDkqQkk8TPzg" targetNode="_mDPeS_KPEeaTM5lTgIAE1w">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.4/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.4/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_OqCFEKUpEeerOY55FDaMag" description="_xRCaVk9_EeeQdthcRQethQ" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_OqCFEaUpEeerOY55FDaMag" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_i1ZTIFHPEeeDkqQkk8TPzg" name="10" sourceNode="_fzXFgFHPEeeDkqQkk8TPzg" targetNode="_mDPeS_KPEeaTM5lTgIAE1w">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74muErTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74muErTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_JfsaUDCxEeuAyprcJPTPWQ" description="_Jfnh0DCxEeuAyprcJPTPWQ" strokeColor="78,188,194">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_JfsaUTCxEeuAyprcJPTPWQ" showIcon="false" labelColor="78,188,194"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_fakZYFZhEee55OSk-vC-7w" name="6/6" sourceNode="_mDPeVfKPEeaTM5lTgIAE1w" targetNode="_fzXFgFHPEeeDkqQkk8TPzg">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.1/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.1/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_2VNzIKUkEeerOY55FDaMag" description="_xQ_XAE9_EeeQdthcRQethQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_2VNzIaUkEeerOY55FDaMag" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fakZYFZhEee55OSk-vC-7w" name="6/6" visible="false" sourceNode="_mDPeVfKPEeaTM5lTgIAE1w" targetNode="_fzXFgFHPEeeDkqQkk8TPzg">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74mHAbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74mHAbTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_2VNzIKUkEeerOY55FDaMag" description="_xQ_XAE9_EeeQdthcRQethQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="77,137,20">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_2VNzIaUkEeerOY55FDaMag" showIcon="false" labelColor="77,137,20"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_fam1oFZhEee55OSk-vC-7w" name="8/6" sourceNode="_mDPeUfKPEeaTM5lTgIAE1w" targetNode="_WQEVEE-EEeeeZ8j7YmiDCQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.1"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_fancsFZhEee55OSk-vC-7w" description="_bjwHIE-CEeeeDdTayR14MQ" strokeColor="224,133,3">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_fancsVZhEee55OSk-vC-7w" showIcon="false" labelColor="224,133,3"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_fam1oFZhEee55OSk-vC-7w" name="6" sourceNode="_mDPeUfKPEeaTM5lTgIAE1w" targetNode="_WQEVEE-EEeeeZ8j7YmiDCQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74lf9LTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74lf9LTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_JfqlIDCxEeuAyprcJPTPWQ" description="_Jfov8DCxEeuAyprcJPTPWQ" strokeColor="251,166,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_JfqlITCxEeuAyprcJPTPWQ" showIcon="false" labelColor="251,166,0"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_otIjMDCwEeuiOLVpQO2TvQ" name="7" sourceNode="_osoM4DCwEeuiOLVpQO2TvQ" targetNode="_fzXFgFHPEeeDkqQkk8TPzg">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74mHAbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74mHAbTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_Jfe-8jCxEeuAyprcJPTPWQ" description="_Jfe-8DCxEeuAyprcJPTPWQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="78,188,194">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_Jfe-8zCxEeuAyprcJPTPWQ" showIcon="false" labelColor="78,188,194"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_otLmgDCwEeuiOLVpQO2TvQ" name="6" sourceNode="_osqpITCwEeuiOLVpQO2TvQ" targetNode="_mDPeUfKPEeaTM5lTgIAE1w">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74mHA7TZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74mHA7TZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_JfjQYjCxEeuAyprcJPTPWQ" description="_JfjQYDCxEeuAyprcJPTPWQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="251,166,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_JfjQYzCxEeuAyprcJPTPWQ" showIcon="false" labelColor="251,166,0"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_otcsQDCwEeuiOLVpQO2TvQ" sourceNode="_or4mADCwEeuiOLVpQO2TvQ" targetNode="_osWgEDCwEeuiOLVpQO2TvQ">
+      <target xmi:type="flow:PowerOutput" href="Robot.flow#_74k44bTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_otdTUDCwEeuiOLVpQO2TvQ" lineStyle="dash" size="2" strokeColor="0,43,60">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Link']/@style"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_otdTUTCwEeuiOLVpQO2TvQ"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Link']"/>
     </ownedDiagramElements>
     <description xmi:type="description_2:DiagramDescription" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_mDPebvKPEeaTM5lTgIAE1w"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_mDPebvKPEeaTM5lTgIAE1w"/>
     <activatedLayers xmi:type="description_2:Layer" href="platform:/plugin/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer"/>
-    <target xmi:type="flow:System" href="Robot.flow#/"/>
+    <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram xmi:id="_ezRyoKT_EeezavZXoDtFGQ" name="Topography - Local">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_ezRyoaT_EeezavZXoDtFGQ" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_ezRyoqT_EeezavZXoDtFGQ">
+  <diagram:DSemanticDiagram uid="_ezRyoKT_EeezavZXoDtFGQ">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_ezRyoaT_EeezavZXoDtFGQ" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_ezRyoqT_EeezavZXoDtFGQ">
         <computedStyleDescriptions xmi:type="style:WorkspaceImageDescription" xmi:id="_ezRyo6T_EeezavZXoDtFGQ" showIcon="false" sizeComputationExpression="aql:self.sizeFromCapacity()" arcWidth="1" arcHeight="1" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset2_standard.svg">
           <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
@@ -848,7 +998,7 @@
         </computedStyleDescriptions>
       </data>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_e0fTkKT_EeezavZXoDtFGQ" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_e0fTkKT_EeezavZXoDtFGQ" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_e0fTkaT_EeezavZXoDtFGQ" type="Sirius" element="_ezRyoKT_EeezavZXoDtFGQ" measurementUnit="Pixel">
         <children xmi:type="notation:Node" xmi:id="_e0hIwKT_EeezavZXoDtFGQ" type="2001" element="_ezRytaT_EeezavZXoDtFGQ">
           <children xmi:type="notation:Node" xmi:id="_e0kMEKT_EeezavZXoDtFGQ" type="5002">
@@ -1013,7 +1163,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_e25uYaT_EeezavZXoDtFGQ"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_e25uYqT_EeezavZXoDtFGQ" fontColor="789660" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyF6cKT_EeezavZXoDtFGQ" points="[30, -14, -145, 66]$[156, -70, -19, 10]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyF6cKT_EeezavZXoDtFGQ" points="[30, -9, -170, 46]$[150, -42, -50, 13]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e29_0KT_EeezavZXoDtFGQ" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e29_0aT_EeezavZXoDtFGQ" id="(0.5,0.5)"/>
         </edges>
@@ -1045,7 +1195,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_e3EGc6T_EeezavZXoDtFGQ"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_e3EGdKT_EeezavZXoDtFGQ" fontColor="1345869" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyDeMqT_EeezavZXoDtFGQ" points="[0, -20, -3, 145]$[1, -148, -2, 17]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyDeMqT_EeezavZXoDtFGQ" points="[-1, -20, 1, 151]$[-2, -151, 0, 20]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3FUkKT_EeezavZXoDtFGQ" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3FUkaT_EeezavZXoDtFGQ" id="(0.5,0.5)"/>
         </edges>
@@ -1061,7 +1211,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_e3FUk6T_EeezavZXoDtFGQ"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_e3FUlKT_EeezavZXoDtFGQ" fontColor="1345869" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyEFRKT_EeezavZXoDtFGQ" points="[-4, 0, 63, 0]$[-67, 0, 0, 0]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyEFRKT_EeezavZXoDtFGQ" points="[-6, 0, 61, 0]$[-64, 0, 3, 0]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3F7oqT_EeezavZXoDtFGQ" id="(0.15,0.65)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3F7o6T_EeezavZXoDtFGQ" id="(0.9571428571428572,0.5857142857142857)"/>
         </edges>
@@ -1093,7 +1243,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_e3HJw6T_EeezavZXoDtFGQ"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_e3HJxKT_EeezavZXoDtFGQ" fontColor="230880" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyFTYKT_EeezavZXoDtFGQ" points="[23, -5, -132, 49]$[125, -43, -30, 11]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyFTYKT_EeezavZXoDtFGQ" points="[30, -11, -125, 43]$[125, -44, -30, 10]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3Hw0KT_EeezavZXoDtFGQ" id="(0.5,0.5)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3Hw0aT_EeezavZXoDtFGQ" id="(0.5,0.5)"/>
         </edges>
@@ -1109,7 +1259,7 @@
           </children>
           <styles xmi:type="notation:ConnectorStyle" xmi:id="_e3Hw06T_EeezavZXoDtFGQ"/>
           <styles xmi:type="notation:FontStyle" xmi:id="_e3Hw1KT_EeezavZXoDtFGQ" fontColor="789660" fontName="Segoe UI" fontHeight="8"/>
-          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyFTZqT_EeezavZXoDtFGQ" points="[50, -2, -400, 6]$[386, -8, -64, 0]"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_kyFTZqT_EeezavZXoDtFGQ" points="[0, 0, -450, 25]$[450, -25, 0, 0]"/>
           <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3IX5qT_EeezavZXoDtFGQ" id="(0.0,0.3333333333333333)"/>
           <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_e3IX56T_EeezavZXoDtFGQ" id="(1.0,0.8333333333333334)"/>
         </edges>
@@ -1131,27 +1281,27 @@
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezRytaT_EeezavZXoDtFGQ" name="Wifi : 4" outgoingEdges="_ezSZwqT_EeezavZXoDtFGQ" width="4" height="4">
-      <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
-      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.2"/>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezRytaT_EeezavZXoDtFGQ" name="Wifi : 4" outgoingEdges="_ezSZwqT_EeezavZXoDtFGQ" width="4" height="4">
+      <target xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74muFbTZEeeolunnT_MYFg"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_ezRytqT_EeezavZXoDtFGQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/antenna.svg">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ezRytqT_EeezavZXoDtFGQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/antenna.svg">
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']/@conditionnalStyles.2/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_ezRyt6T_EeezavZXoDtFGQ" name="Central_Unit">
-      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.0"/>
-      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.0"/>
-      <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_FkouMKUmEeerOY55FDaMag" name="1000" visible="false" outgoingEdges="_FkwC8KUmEeerOY55FDaMag" width="3" height="3" resizeKind="NSEW">
-        <target xmi:type="flow:PowerOutput" href="Robot.flow#//@elements.0/@powerOutputs.0"/>
-        <semanticElements xmi:type="flow:PowerOutput" href="Robot.flow#//@elements.0/@powerOutputs.0"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_ezRyt6T_EeezavZXoDtFGQ" name="Central_Unit">
+      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#_74hOgLTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#_74hOgLTZEeeolunnT_MYFg"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_FkouMKUmEeerOY55FDaMag" name="1000" visible="false" outgoingEdges="_FkwC8KUmEeerOY55FDaMag" width="3" height="3" resizeKind="NSEW">
+        <target xmi:type="flow:PowerOutput" href="Robot.flow#_74k44bTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:PowerOutput" href="Robot.flow#_74k44bTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_FkrxgKUmEeerOY55FDaMag" borderColor="239,41,41" color="239,41,41">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_FkrxgKUmEeerOY55FDaMag" borderColor="239,41,41" color="239,41,41">
           <description xmi:type="style:BundledImageDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Power']/@containerMappings[name='importSystem']/@borderedNodeMappings[name='PowerOutputNode']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Power']/@containerMappings[name='importSystem']/@borderedNodeMappings[name='PowerOutputNode']"/>
@@ -1159,52 +1309,52 @@
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_Tuk9AKUpEeerOY55FDaMag" labelSize="10" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136" backgroundStyle="Liquid" foregroundColor="243,243,243">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Tuk9AKUpEeerOY55FDaMag" labelSize="10" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136" backgroundStyle="Liquid" foregroundColor="243,243,243">
         <labelFormat>italic</labelFormat>
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:ContainerMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezRyuaT_EeezavZXoDtFGQ" name="DSP" outgoingEdges="_ezSZxaT_EeezavZXoDtFGQ" incomingEdges="_ezSZwqT_EeezavZXoDtFGQ" width="4" height="4">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.0"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezRyuaT_EeezavZXoDtFGQ" name="DSP" outgoingEdges="_ezSZxaT_EeezavZXoDtFGQ" incomingEdges="_ezSZwqT_EeezavZXoDtFGQ" width="4" height="4">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74icoLTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_ezRyuqT_EeezavZXoDtFGQ" showIcon="false" description="_ezRyo6T_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset2_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ezRyuqT_EeezavZXoDtFGQ" showIcon="false" description="_ezRyo6T_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset2_standard.svg"/>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezRyu6T_EeezavZXoDtFGQ" name="Motion_Engine" incomingEdges="_ezSZxaT_EeezavZXoDtFGQ _ezSZyKT_EeezavZXoDtFGQ _ezSZzqT_EeezavZXoDtFGQ" width="7" height="7">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.0/@elements.1"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezRyu6T_EeezavZXoDtFGQ" name="Motion_Engine" incomingEdges="_ezSZxaT_EeezavZXoDtFGQ _ezSZyKT_EeezavZXoDtFGQ _ezSZzqT_EeezavZXoDtFGQ" width="7" height="7">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74kR0LTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_Op6JQaUpEeerOY55FDaMag" showIcon="false" description="_Op6JQKUpEeerOY55FDaMag" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_high.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_Op6JQaUpEeerOY55FDaMag" showIcon="false" description="_Op6JQKUpEeerOY55FDaMag" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_high.svg"/>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_IUIaUKUmEeerOY55FDaMag" name="1000" visible="false" width="6" height="6" resizeKind="NSEW">
-        <target xmi:type="flow:Fan" href="Robot.flow#//@elements.0/@elements.2"/>
-        <semanticElements xmi:type="flow:Fan" href="Robot.flow#//@elements.0/@elements.2"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_IUIaUKUmEeerOY55FDaMag" name="1000" visible="false" width="6" height="6" resizeKind="NSEW">
+        <target xmi:type="flow:Fan" href="Robot.flow#_74k44LTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Fan" href="Robot.flow#_74k44LTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_IUIaUaUmEeerOY55FDaMag" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_IUIaUaUmEeerOY55FDaMag" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_ezSZsKT_EeezavZXoDtFGQ" name="CaptureSubSystem">
-      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.1"/>
-      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#//@elements.1"/>
-      <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_Fks_oKUmEeerOY55FDaMag" visible="false" incomingEdges="_FkwC8KUmEeerOY55FDaMag" width="3" height="3" resizeKind="NSEW">
-        <target xmi:type="flow:PowerInput" href="Robot.flow#//@elements.1/@powerInputs.0"/>
-        <semanticElements xmi:type="flow:PowerInput" href="Robot.flow#//@elements.1/@powerInputs.0"/>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_ezSZsKT_EeezavZXoDtFGQ" name="CaptureSubSystem">
+      <target xmi:type="flow:CompositeProcessor" href="Robot.flow#_74lf8bTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:CompositeProcessor" href="Robot.flow#_74lf8bTZEeeolunnT_MYFg"/>
+      <ownedBorderedNodes xmi:type="diagram:DNode" uid="_Fks_oKUmEeerOY55FDaMag" visible="false" incomingEdges="_FkwC8KUmEeerOY55FDaMag" width="3" height="3" resizeKind="NSEW">
+        <target xmi:type="flow:PowerInput" href="Robot.flow#_74muFLTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:PowerInput" href="Robot.flow#_74muFLTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_Fks_oaUmEeerOY55FDaMag" borderColor="114,159,207" color="114,159,207">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_Fks_oaUmEeerOY55FDaMag" borderColor="114,159,207" color="114,159,207">
           <description xmi:type="style:BundledImageDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Power']/@containerMappings[name='importSystem']/@borderedNodeMappings[name='PowerInputNode']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Power']/@containerMappings[name='importSystem']/@borderedNodeMappings[name='PowerInputNode']"/>
@@ -1212,141 +1362,141 @@
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_TulkEKUpEeerOY55FDaMag" labelSize="10" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136" backgroundStyle="Liquid" foregroundColor="243,243,243">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_TulkEKUpEeerOY55FDaMag" labelSize="10" borderSize="1" borderSizeComputationExpression="1" borderColor="136,136,136" backgroundStyle="Liquid" foregroundColor="243,243,243">
         <labelFormat>italic</labelFormat>
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:ContainerMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezSZsqT_EeezavZXoDtFGQ" name="Radar_Capture" outgoingEdges="_ezSZyKT_EeezavZXoDtFGQ _ezSZy6T_EeezavZXoDtFGQ" incomingEdges="_ezSZv6T_EeezavZXoDtFGQ" width="6" height="6">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.0"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezSZsqT_EeezavZXoDtFGQ" name="Radar_Capture" outgoingEdges="_ezSZyKT_EeezavZXoDtFGQ _ezSZy6T_EeezavZXoDtFGQ" incomingEdges="_ezSZv6T_EeezavZXoDtFGQ" width="6" height="6">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74lf8rTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_ezSZs6T_EeezavZXoDtFGQ" showIcon="false" description="_ezRypaT_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ezSZs6T_EeezavZXoDtFGQ" showIcon="false" description="_ezRypaT_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg"/>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezSZtKT_EeezavZXoDtFGQ" name="Engine" incomingEdges="_ezSZy6T_EeezavZXoDtFGQ" width="6" height="6">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.3"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezSZtKT_EeezavZXoDtFGQ" name="Engine" incomingEdges="_ezSZy6T_EeezavZXoDtFGQ" width="6" height="6">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muELTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_ezSZtaT_EeezavZXoDtFGQ" showIcon="false" description="_ezRypqT_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ezSZtaT_EeezavZXoDtFGQ" showIcon="false" description="_ezRypqT_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/chipset_standard.svg"/>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezSZtqT_EeezavZXoDtFGQ" name="GPU" outgoingEdges="_ezSZzqT_EeezavZXoDtFGQ" incomingEdges="_ezSZvKT_EeezavZXoDtFGQ" width="6" height="6">
-        <target xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
-        <semanticElements xmi:type="flow:Processor" href="Robot.flow#//@elements.1/@elements.4"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezSZtqT_EeezavZXoDtFGQ" name="GPU" outgoingEdges="_ezSZzqT_EeezavZXoDtFGQ" incomingEdges="_ezSZvKT_EeezavZXoDtFGQ" width="6" height="6">
+        <target xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Processor" href="Robot.flow#_74muEbTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_88vZYKUnEeerOY55FDaMag" showIcon="false" description="_ezRypaT_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg"/>
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_88vZYKUnEeerOY55FDaMag" showIcon="false" description="_ezRypaT_EeezavZXoDtFGQ" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/cpu_standard.svg"/>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@containerMappings[name='System']/@subNodeMappings[name='Processor']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezSZuKT_EeezavZXoDtFGQ" name="Back_Camera : 6" outgoingEdges="_ezSZvKT_EeezavZXoDtFGQ" width="6" height="6">
-        <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
-        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.1"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezSZuKT_EeezavZXoDtFGQ" name="Back_Camera : 6" outgoingEdges="_ezSZvKT_EeezavZXoDtFGQ" width="6" height="6">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHALTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_ezSZuaT_EeezavZXoDtFGQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/camera.svg">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ezSZuaT_EeezavZXoDtFGQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/camera.svg">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']/@conditionnalStyles.0/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_ezSZuqT_EeezavZXoDtFGQ" name="Radar : 8" outgoingEdges="_ezSZv6T_EeezavZXoDtFGQ" width="8" height="8">
-        <target xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
-        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#//@elements.1/@elements.2"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_ezSZuqT_EeezavZXoDtFGQ" name="Radar : 8" outgoingEdges="_ezSZv6T_EeezavZXoDtFGQ" width="8" height="8">
+        <target xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:DataSource" href="Robot.flow#_74mHArTZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_ezSZu6T_EeezavZXoDtFGQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/radar.svg">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_ezSZu6T_EeezavZXoDtFGQ" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/radar.svg">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']/@conditionnalStyles.1/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@nodeMappings[name='Data%20Source']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_aB4jkKUoEeerOY55FDaMag" name="20" visible="false" width="6" height="6" resizeKind="NSEW">
-        <target xmi:type="flow:Fan" href="Robot.flow#//@elements.1/@elements.5"/>
-        <semanticElements xmi:type="flow:Fan" href="Robot.flow#//@elements.1/@elements.5"/>
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_aB4jkKUoEeerOY55FDaMag" name="20" visible="false" width="6" height="6" resizeKind="NSEW">
+        <target xmi:type="flow:Fan" href="Robot.flow#_74muE7TZEeeolunnT_MYFg"/>
+        <semanticElements xmi:type="flow:Fan" href="Robot.flow#_74muE7TZEeeolunnT_MYFg"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_aB4jkaUoEeerOY55FDaMag" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_aB4jkaUoEeerOY55FDaMag" showIcon="false" workspacePath="/fr.obeo.dsl.designer.sample.flow.design/images/fan.svg">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_2:NodeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Temperature']/@containerMappings[name='importSystem']/@subNodeMappings[name='Fan']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_ezSZvKT_EeezavZXoDtFGQ" name="6/6" sourceNode="_ezSZuKT_EeezavZXoDtFGQ" targetNode="_ezSZtqT_EeezavZXoDtFGQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.1/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.1/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_2VFQQKUkEeerOY55FDaMag" description="_ezRyrKT_EeezavZXoDtFGQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_2VFQQaUkEeerOY55FDaMag" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ezSZvKT_EeezavZXoDtFGQ" name="6/6" sourceNode="_ezSZuKT_EeezavZXoDtFGQ" targetNode="_ezSZtqT_EeezavZXoDtFGQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74mHAbTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74mHAbTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_2VFQQKUkEeerOY55FDaMag" description="_ezRyrKT_EeezavZXoDtFGQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="77,137,20">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_2VFQQaUkEeerOY55FDaMag" showIcon="false" labelColor="77,137,20"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_ezSZv6T_EeezavZXoDtFGQ" name="8/6" sourceNode="_ezSZuqT_EeezavZXoDtFGQ" targetNode="_ezSZsqT_EeezavZXoDtFGQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.2/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.2/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_ezSZwKT_EeezavZXoDtFGQ" description="_ezRyqqT_EeezavZXoDtFGQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="224,133,3">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_ezSZwaT_EeezavZXoDtFGQ" showIcon="false" labelColor="224,133,3"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ezSZv6T_EeezavZXoDtFGQ" name="8/6" sourceNode="_ezSZuqT_EeezavZXoDtFGQ" targetNode="_ezSZsqT_EeezavZXoDtFGQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74mHA7TZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74mHA7TZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ezSZwKT_EeezavZXoDtFGQ" description="_ezRyqqT_EeezavZXoDtFGQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="224,133,3">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ezSZwaT_EeezavZXoDtFGQ" showIcon="false" labelColor="224,133,3"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_ezSZwqT_EeezavZXoDtFGQ" name="4/4" sourceNode="_ezRytaT_EeezavZXoDtFGQ" targetNode="_ezRyuaT_EeezavZXoDtFGQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.2/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.2/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_ezSZw6T_EeezavZXoDtFGQ" description="_ezRyrKT_EeezavZXoDtFGQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_ezSZxKT_EeezavZXoDtFGQ" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ezSZwqT_EeezavZXoDtFGQ" name="4/4" sourceNode="_ezRytaT_EeezavZXoDtFGQ" targetNode="_ezRyuaT_EeezavZXoDtFGQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74muFrTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74muFrTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ezSZw6T_EeezavZXoDtFGQ" description="_ezRyrKT_EeezavZXoDtFGQ" lineStyle="dash" targetArrow="InputClosedArrow" strokeColor="77,137,20">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ezSZxKT_EeezavZXoDtFGQ" showIcon="false" labelColor="77,137,20"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Data%20Source%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_ezSZxaT_EeezavZXoDtFGQ" name="4/10" sourceNode="_ezRyuaT_EeezavZXoDtFGQ" targetNode="_ezRyu6T_EeezavZXoDtFGQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.0/@elements.0/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.0/@elements.0/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_ezSZxqT_EeezavZXoDtFGQ" description="_ezRyrqT_EeezavZXoDtFGQ" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_ezSZx6T_EeezavZXoDtFGQ" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ezSZxaT_EeezavZXoDtFGQ" name="4/10" sourceNode="_ezRyuaT_EeezavZXoDtFGQ" targetNode="_ezRyu6T_EeezavZXoDtFGQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74jDsLTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74jDsLTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ezSZxqT_EeezavZXoDtFGQ" description="_ezRyrqT_EeezavZXoDtFGQ" strokeColor="77,137,20">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ezSZx6T_EeezavZXoDtFGQ" showIcon="false" labelColor="77,137,20"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_ezSZyKT_EeezavZXoDtFGQ" name="8/6" sourceNode="_ezSZsqT_EeezavZXoDtFGQ" targetNode="_ezRyu6T_EeezavZXoDtFGQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_ezSZyaT_EeezavZXoDtFGQ" description="_ezRysKT_EeezavZXoDtFGQ" routingStyle="manhattan" strokeColor="224,133,3">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ezSZyKT_EeezavZXoDtFGQ" name="8/6" sourceNode="_ezSZsqT_EeezavZXoDtFGQ" targetNode="_ezRyu6T_EeezavZXoDtFGQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74lf87TZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74lf87TZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ezSZyaT_EeezavZXoDtFGQ" description="_ezRysKT_EeezavZXoDtFGQ" routingStyle="manhattan" strokeColor="224,133,3">
         <customFeatures>routingStyle</customFeatures>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_ezSZyqT_EeezavZXoDtFGQ" showIcon="false" labelColor="224,133,3"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ezSZyqT_EeezavZXoDtFGQ" showIcon="false" labelColor="224,133,3"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_ezSZy6T_EeezavZXoDtFGQ" name="8/6" sourceNode="_ezSZsqT_EeezavZXoDtFGQ" targetNode="_ezSZtKT_EeezavZXoDtFGQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.1"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.0/@outgoingFlows.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_ezSZzKT_EeezavZXoDtFGQ" description="_ezRysKT_EeezavZXoDtFGQ" strokeColor="224,133,3">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_ezSZzaT_EeezavZXoDtFGQ" showIcon="false" labelColor="224,133,3"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ezSZy6T_EeezavZXoDtFGQ" name="8/6" sourceNode="_ezSZsqT_EeezavZXoDtFGQ" targetNode="_ezSZtKT_EeezavZXoDtFGQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74lf9LTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74lf9LTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_ezSZzKT_EeezavZXoDtFGQ" description="_ezRysKT_EeezavZXoDtFGQ" strokeColor="224,133,3">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_ezSZzaT_EeezavZXoDtFGQ" showIcon="false" labelColor="224,133,3"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_ezSZzqT_EeezavZXoDtFGQ" name="6/10" sourceNode="_ezSZtqT_EeezavZXoDtFGQ" targetNode="_ezRyu6T_EeezavZXoDtFGQ">
-      <target xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.4/@outgoingFlows.0"/>
-      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#//@elements.1/@elements.4/@outgoingFlows.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_Op9MkKUpEeerOY55FDaMag" description="_ezRyrqT_EeezavZXoDtFGQ" strokeColor="77,137,20">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_Op9MkaUpEeerOY55FDaMag" showIcon="false" labelColor="77,137,20"/>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_ezSZzqT_EeezavZXoDtFGQ" name="6/10" sourceNode="_ezSZtqT_EeezavZXoDtFGQ" targetNode="_ezRyu6T_EeezavZXoDtFGQ">
+      <target xmi:type="flow:DataFlow" href="Robot.flow#_74muErTZEeeolunnT_MYFg"/>
+      <semanticElements xmi:type="flow:DataFlow" href="Robot.flow#_74muErTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_Op9MkKUpEeerOY55FDaMag" description="_ezRyrqT_EeezavZXoDtFGQ" strokeColor="77,137,20">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_Op9MkaUpEeerOY55FDaMag" showIcon="false" labelColor="77,137,20"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer/@edgeMappings[name='Processor%20%20to%20Processor']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_FkwC8KUmEeerOY55FDaMag" visible="false" sourceNode="_FkouMKUmEeerOY55FDaMag" targetNode="_Fks_oKUmEeerOY55FDaMag">
-      <target xmi:type="flow:PowerOutput" href="Robot.flow#//@elements.0/@powerOutputs.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_FkwqAKUmEeerOY55FDaMag" lineStyle="dash" size="2">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_FkwC8KUmEeerOY55FDaMag" visible="false" sourceNode="_FkouMKUmEeerOY55FDaMag" targetNode="_Fks_oKUmEeerOY55FDaMag">
+      <target xmi:type="flow:PowerOutput" href="Robot.flow#_74k44bTZEeeolunnT_MYFg"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_FkwqAKUmEeerOY55FDaMag" lineStyle="dash" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Power']/@edgeMappings[name='Link']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_FkwqAaUmEeerOY55FDaMag"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_FkwqAaUmEeerOY55FDaMag"/>
       </ownedStyle>
       <actualMapping xmi:type="description_2:EdgeMapping" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@additionalLayers[name='Power']/@edgeMappings[name='Link']"/>
     </ownedDiagramElements>
     <description xmi:type="description_2:DiagramDescription" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_ezSZ0aT_EeezavZXoDtFGQ"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_ezSZ0aT_EeezavZXoDtFGQ"/>
     <activatedLayers xmi:type="description_2:Layer" href="platform:/resource/fr.obeo.dsl.designer.sample.flow.design/description/flow.odesign#//@ownedViewpoints[name='Exchanges']/@ownedRepresentations[name='Topography']/@defaultLayer"/>
-    <target xmi:type="flow:System" href="Robot.flow#/"/>
+    <target xmi:type="flow:System" href="Robot.flow#_74gncLTZEeeolunnT_MYFg"/>
   </diagram:DSemanticDiagram>
 </xmi:XMI>


### PR DESCRIPTION
On the topology diagram, the edge's label displayed the load and
capacity values. As edit tool masks are not handled in OCP, the label
has been simplfied.

Bug: https://github.com/eclipse-sirius/sirius-components/issues/154
Signed-off-by: Steve Monnier <steve.monnier@obeo.fr>